### PR TITLE
Add jinja_markdown to support Markdown

### DIFF
--- a/postman_doc_gen/document_generator.py
+++ b/postman_doc_gen/document_generator.py
@@ -93,7 +93,7 @@ class DocumentGenerator:
         :param templates_dir: the directory containing the template
         :return: the JINJA 2 template
         """
-        env = Environment(loader=FileSystemLoader(templates_dir))
+        env = Environment(loader=FileSystemLoader(templates_dir), extensions=['jinja_markdown.MarkdownExtension'])
         return env.get_template(TEMPLATE_FILE_NAME)
 
     @staticmethod

--- a/postman_doc_gen/templates/index.html
+++ b/postman_doc_gen/templates/index.html
@@ -81,7 +81,9 @@
                                         <p>{{collection.name}}</p>
                                     </div>
                                     <div class="collection-description">
-                                        <p>{{collection.description}}</p>
+<p>{% markdown %}
+{{collection.description|safe}}
+{% endmarkdown %}</p>
                                     </div>
                                 </div>
                             </div>
@@ -102,7 +104,9 @@
                                     {% endif %}
                                     {%- if api.description is defined and api.description is not none%}
                                     <div class="description request-description">
-                                        <p>{{api.description|safe}}</p>
+<p>{% markdown %}
+{{api.description|safe}}
+{% endmarkdown %}</p>
                                     </div>
                                     {% endif %}
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 fastjsonschema==2.14.4
 Jinja2==2.11.1
 MarkupSafe==1.1.1
+jinja_markdown==1.200630

--- a/setup.py
+++ b/setup.py
@@ -20,5 +20,5 @@ setup(name='postman_doc_gen',
 
       zip_safe=False,
 
-      setup_requires=['fastjsonschema>=2.14', 'Jinja2>=2.11', 'MarkupSafe>=1.1'],
+      setup_requires=['fastjsonschema>=2.14', 'Jinja2>=2.11', 'MarkupSafe>=1.1', 'jinja_markdown>=1.200630'],
       python_requires='>=3.0')


### PR DESCRIPTION
Postman descriptions support Markdown, which right now cannot be rendered properly. This provides additional support for Markdown, allowing a better transition from the Postman export to external documentation.

This does add a requirement of jinja_markdown 1.200630 though.

It is not perfect, but, it works generally:

![image](https://user-images.githubusercontent.com/5909741/90556634-3d076f80-e167-11ea-893b-c6cd62781d57.png)
