### PR TITLE
Bugfix: explicit encoding type declaration

### DIFF
--- a/postman_doc_gen/document_generator.py
+++ b/postman_doc_gen/document_generator.py
@@ -72,7 +72,7 @@ class DocumentGenerator:
         copy_tree(css_dir, os.path.join(output_dir, CSS_DIR))
         copy_tree(js_dir, os.path.join(output_dir, JS_DIR))
 
-        with open(filename, 'w') as fh:
+        with open(filename, 'w' , encoding='utf-8')  as fh:
             fh.write(template.render(
                 download_enabled=download_enabled,
                 collection=self.api_collection,
@@ -106,7 +106,7 @@ class DocumentGenerator:
         :param file_name: file path
         :return: the json file at path
         """
-        with open(file_name) as f:
+        with open(file_name, 'r', encoding='utf-8')  as f:
             json_file = json.load(f)
         return json_file
 


### PR DESCRIPTION
Bugfix for: Issue #21 #23 

From the Python 3 [docs](https://docs.python.org/3/library/functions.html#open) for open():
> if encoding is not specified the encoding used is platform-dependent: [locale.getencoding()](https://docs.python.org/3/library/locale.html#locale.getencoding) is called to get the current locale encoding.

In Windows,it uses legacy encodings for the system encoding (the ANSI Code Page), that cause these issues.

Although it can be solved by two things that doen't need change anything
1. [PEP 540 (Python3.7)](https://peps.python.org/pep-0540/), Python add Add a new “UTF-8 Mode” , people can solve these issue via the -X utf8 command line option
2. just waiting for [PEP 686 (Python 3.15)](https://github.com/python/peps/blob/main/pep-0686.rst) that Python will enable UTF-8 mode by default.

But I think user will be happy u to have these small to make it work without typing command option or waiting it solved
